### PR TITLE
Adds Grunt build step to deploy workflow (including sample theme that needs this step)

### DIFF
--- a/.circleci/build-assets.sh
+++ b/.circleci/build-assets.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+#==================================================
+# This runs any build steps needed for the website.
+#==================================================
+
+NPM=`which npm`
+if [ ! -x "$NPM" ]
+then
+    echo -e "\nError: Executable npm not found on path"
+    exit 1
+fi
+
+GRUNT=`which grunt`
+if [ ! -x "$GRUNT" ]
+then
+    echo -e "\nError: Executable grunt not found on path"
+    exit 1
+fi
+
+SASS=`which sass`
+if [ ! -x "$SASS" ]
+then
+    echo -e "\nError: Executable sass not found on path"
+    exit 1
+fi
+
+# Look for Gruntfile.js occurrences NOT in node_modules
+echo -e "\nLooking for Gruntfile.js occurrences NOT in node_modules.."
+FILE=Gruntfile.*js
+for d in `find . \( -name node_modules -or -name .git \) -prune -o -name "$FILE" | grep "$FILE"`
+do
+    # Change into containing directory
+    echo -e "\nGruntfile found, changing directories into: ${d%/*}"
+    cd ${d%/*}
+
+    # Install any dependencies, if we find packages.json
+    if [ -f 'package.json' ]
+    then
+
+        echo -e "\npackage.json found in ${d%/*}"
+
+        #NODE_SASS_INSTALLED=$(npm list | grep node-sass >/dev/null)
+        #if [ -z $NODE_SASS_INSTALLED ]
+        #then
+            # this is necessary if you run something besides Linux, like MacOS, locally as Lando
+            # runs Linux and the node-sass binary can't be shared between operating systems
+        #    echo -e "\nnode-sass found, rebuilding it's binary..."
+        #    npm rebuild node-sass --force >/dev/null 2>&1
+        #fi
+
+        echo -e "\nRunning 'npm install'"
+        npm install
+    fi
+
+    # Run grunt
+    echo -e "\nRunning 'grunt'"
+    $GRUNT
+
+    # Change back again
+    echo -e "\nchanged directories back into:"
+    cd -
+done
+
+exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,22 @@ jobs:
                 name: install dev dependencies
                 command: composer install --no-ansi --no-interaction --optimize-autoloader --no-progress
 
+            - run:
+                name: mark set-up-node as executable
+                command: chmod +x ./.circleci/set-up-node.sh
+
+            - run:
+                name: install node ecosystem
+                command: ./.circleci/set-up-node.sh
+
+            - run:
+                name: mark build-assets as executable
+                command: chmod +x ./.circleci/build-assets.sh
+
+            - run:
+                name: build assets with grunt
+                command: ./.circleci/build-assets.sh
+
             - save_cache:
                 key: composer-cache
                 paths:
@@ -114,6 +130,22 @@ jobs:
             - run:
                 name: build assets
                 command: composer -n build-assets
+
+            - run:
+                name: mark set-up-node as executable
+                command: chmod +x ./.circleci/set-up-node.sh
+
+            - run:
+                name: install node ecosystem
+                command: ./.circleci/set-up-node.sh
+
+            - run:
+                name: mark build-assets as executable
+                command: chmod +x ./.circleci/build-assets.sh
+
+            - run:
+                name: build assets with grunt
+                command: ./.circleci/build-assets.sh
 
             - run:
                 name: deploy to Pantheon

--- a/.circleci/set-up-node.sh
+++ b/.circleci/set-up-node.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+#===============================================
+# This installs the node / grunt / sass tooling.
+#===============================================
+
+# 0. Update / install GNUPG
+apt-get update && apt-get install -y gnupg
+
+# 1. Node
+NPM=`which npm`
+if [ ! -x "$NPM" ]
+then
+    echo -e "\nNPM not found on path"
+    # per https://github.com/nodesource/distributions/blob/master/README.md
+    curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+fi
+
+# 2. Grunt
+GRUNT=`which grunt`
+if [ ! -x "$GRUNT" ]
+then
+    echo -e "\nGrunt not found on path"
+    npm install -g grunt-cli
+fi
+
+# 3. SassJS
+SASS=`which sass`
+if [ ! -x "$SASS" ]
+then
+    echo -e "\nSass not found on path"
+    npm install -g sass
+fi
+
+echo -e "\nNPM version:"
+npm --version
+
+echo -e "\nGrunt version:"
+grunt --version
+
+echo -e "\nSass version:"
+sass --version
+
+exit 0

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,11 @@
     },
     {
       "type": "vcs",
-      "url": "https://github.com/MITLibraries/Custom-Child-Theme-Post-Types"
+      "url": "https://github.com/MITLibraries/cms1b-courtyard"
     }
   ],
   "require": {
+    "MITLibraries/cms1b-courtyard": "^0.1.1",
     "composer/installers": "^1.3.0",
     "matt-bernhardt/mitlib-secrets-widget": "^0.1.0",
     "pantheon-systems/quicksilver-pushback": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e35d61c48194f44a5a2880115183b78",
+    "content-hash": "e1aee97c6905c7bc518c501006a7d133",
     "packages": [
+        {
+            "name": "MITLibraries/cms1b-courtyard",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MITLibraries/cms1b-courtyard.git",
+                "reference": "c814456d85194f89aa1373f01564f9627dc29589"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/cms1b-courtyard/zipball/c814456d85194f89aa1373f01564f9627dc29589",
+                "reference": "c814456d85194f89aa1373f01564f9627dc29589",
+                "shasum": ""
+            },
+            "type": "wordpress-theme",
+            "license": [
+                "GPL3"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Bernhardt",
+                    "email": "mjbernha@mit.edu"
+                }
+            ],
+            "description": "A WordPress theme that is compatible with Pantheon deploys and CircleCI builds",
+            "support": {
+                "source": "https://github.com/MITLibraries/cms1b-courtyard/tree/0.1.1",
+                "issues": "https://github.com/MITLibraries/cms1b-courtyard/issues"
+            },
+            "time": "2019-02-08T21:39:11+00:00"
+        },
         {
             "name": "composer/installers",
             "version": "v1.6.0",


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a new step to the deploy process that Pantheon uses - the Grunt task runner that will perform needed steps on our WordPress themes. This work is added both to the "Build" and "Build and Deploy" workflows.

#### Helpful background context (if appropriate)
We use Grunt on our servers currently to perform some build steps on our WordPress themes. Examples include:
1. Modifying the theme release information to indicate what branch and commit were deployed
2. Minifiying and uglifying Javascript
3. Prefixing and minifying CSS styles

Moving our sites to Pantheon will require the preservation of these steps, or the accomplishment of this work via some other means.

#### How can a reviewer manually see the effects of these changes?
Inspect the CircleCI output logs, and check the resulting website to make sure the theme:
1. reports a branch and commit in its version string
2. loads the right stylesheet

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/WRP-274

#### Requires new or updated plugins, themes, or libraries?
NO - everything happens automatically

#### Requires change to deploy process?
NO :-)
